### PR TITLE
fix: remove npm audit from circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,6 @@ jobs:
       - run:
           name: upload coverage report
           command: bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
-      # - run:
-      #     name: audit
-      #     command: npm audit
       - run:
           name: do a release
           command: npx semantic-release


### PR DESCRIPTION
Moving to use GitHub Security and Dependabot for tracking and patching vulnerabilities