### PR TITLE
feat: switch to github packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: install NPM dependencies
           command: |
-            echo -e "//registry.npmjs.org/:_authToken=$NPM_TOKEN\nscope=@oneflow" > .npmrc
+            echo -e "registry=https://npm.pkg.github.com/oneflow\n//npm.pkg.github.com/:_authToken=$GH_TOKEN\nscope=@oneflow" > .npmrc
             npm install
       - save_cache:
           key: v2-npm-deps-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}


### PR DESCRIPTION
This PR switches the repo from using NPM private packages to GitHub Packages. More information can be found [here](https://oneflow.atlassian.net/wiki/spaces/DEV/pages/1846444059/JavaScript+TypeScript+Package+Manager)