### PR TITLE
fix: add moment timezone to formatDate helper

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -1,5 +1,5 @@
 const utils = require('./utils');
-const moment = require('moment');
+const moment = require('moment-timezone');
 
 /**
  * @exports date
@@ -97,12 +97,17 @@ helpers.date = (...args) => helpers.moment(...args);
  * <!-- 'Wednesday' -->
  * ```
  * @param {String} date - The date to format
- * @param {String} pattern - [optional] The pattern to use when formatting the date
+ * @param {String} _format - [optional] The pattern to use when formatting the date
+ * @param {String} _timezone - [optional] The timezone to set the date to
  * @api public
  */
-helpers.formatDate = function(date, _format) {
+helpers.formatDate = function(date, _format, _timezone) {
   let format = _format;
   if (!format || !utils.isString(format)) format = undefined;
+  let timezone = _timezone;
+  if (timezone && utils.isString(timezone)) {
+    return date ? moment(date).tz(timezone).format(format) : '';
+  }
   return date ? moment(date).utc().format(format).replace('Z', '') : '';
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5544,12 +5544,14 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
     },
     "moment-timezone": {
       "version": "0.5.34",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
       "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "dev": true,
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5544,8 +5544,15 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "release": "semantic-release"
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "moment-timezone": "^0.5.34"
   },
   "peerDependencies": {
     "handlebars": "4.x",

--- a/package.json
+++ b/package.json
@@ -74,12 +74,12 @@
     "release": "semantic-release"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
-    "moment-timezone": "^0.5.34"
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "handlebars": "4.x",
-    "moment": "2.x"
+    "moment": "2.x",
+    "moment-timezone": "0.5.x"
   },
   "devDependencies": {
     "docdash": "^1.1.0",
@@ -89,6 +89,7 @@
     "jsdoc": "3.6.7",
     "mockdate": "2.0.2",
     "moment": "2.24.0",
+    "moment-timezone": "^0.5.34",
     "semantic-release": "18.0.0"
   },
   "keywords": [

--- a/test/date.js
+++ b/test/date.js
@@ -75,6 +75,10 @@ describe('date', function() {
       const fn = hbs.compile("{{formatDate date 'dddd'}}");
       assert.equal(fn({ date: new Date('2017-01-18T10:54:00.000Z') }), 'Wednesday');
     });
+    it('returns a date in specified timezone if timezone supplied', () => {
+      const fn = hbs.compile("{{formatDate date 'dddd' 'America/Edmonton'}}");
+      assert.equal(fn({ date: new Date('2017-01-19T05:00:00.000Z') }), 'Wednesday');
+    });
   });
 
   describe('niceDate', () => {


### PR DESCRIPTION
Kanbanize Card: https://hpinc.kanbanize.com/ctrl_board/55/cards/18885/details/ 

**Change:**
- Add param in formatDate to change the timezone for the date

**Reason:**
There is a discrepancy between the dates that would be shown via the Greensheet timezone vs the order details/batch details due to the latter formatting the dates to the account settings timezone while the greensheet uses the handlebar helper that always sets the time to UTC.

update vulnerable dependencies